### PR TITLE
Build libight statically and include manually libc++_static in the toolchain

### DIFF
--- a/scripts/build_target.sh
+++ b/scripts/build_target.sh
@@ -34,7 +34,7 @@ export RANLIB=${TOOL_PATH}-ranlib
 export STRIP=${TOOL_PATH}-strip
 
 export CPPFLAGS="${CPPFLAGS} --sysroot=${SYSROOT} -I${SYSROOT}/usr/include -I${ANDROID_TOOLCHAIN}/include"
-export LDFLAGS="${LDFLAGS} -L${SYSROOT}/usr/lib -L${ANDROID_TOOLCHAIN}/lib -lc++_shared -lm"
+export LDFLAGS="${LDFLAGS} -L${SYSROOT}/usr/lib -L${ANDROID_TOOLCHAIN}/lib -lc++_static -latomic -lm"
 
 (
     cd $ROOTDIR
@@ -45,7 +45,8 @@ export LDFLAGS="${LDFLAGS} -L${SYSROOT}/usr/lib -L${ANDROID_TOOLCHAIN}/lib -lc++
     echo "Configure with --host=${ARCH} and toolchain ${ANDROID_TOOLCHAIN}"
     test -x ${ROOTDIR}/libight/configure || (cd ../libight/ && autoreconf -i)
     ${ROOTDIR}/libight/configure --host=${ARCH} --with-sysroot=${SYSROOT} \
-      --with-libevent=builtin --with-libyaml-cpp=builtin --with-libboost=builtin
+      --with-libevent=builtin --with-libyaml-cpp=builtin --with-libboost=builtin \
+      --disable-shared
     make V=0
     # XXX: We want to see whether tests builds but of course they cannot run
     make check-am V=0 || true

--- a/scripts/make_toolchain.sh
+++ b/scripts/make_toolchain.sh
@@ -25,3 +25,11 @@ bash $MAKE_TOOLCHAIN \
   --llvm-version=3.5 \
   --stl=libc++ \
   --system=linux-x86_64
+
+if [ $ARCH = x86 ]; then
+    cp $NDK/android-ndk-r10d/sources/cxx-stl/llvm-libc++/libs/x86/libc++_static.a $INSTALL_DIR/sysroot/usr/lib/
+elif [ $ARCH = arm-linux-androideabi ]; then
+    cp $NDK/android-ndk-r10d/sources/cxx-stl/llvm-libc++/libs/armeabi/libc++_static.a $INSTALL_DIR/sysroot/usr/lib/
+elif [ $ARCH = mipsel-linux-android ]; then
+    cp $NDK/android-ndk-r10d/sources/cxx-stl/llvm-libc++/libs/mips/libc++_static.a $INSTALL_DIR/sysroot/usr/lib/
+fi


### PR DESCRIPTION
We have found out that it is not possible to dynamically load libight from the Java side, since Android does not allow linking libraries whose name do not end with ".so" (e.g., libevent-2.0.so.5). Therefore, we have to statically build libight.

Furthermore, the NDK's make_toolchain.sh does not include lib++_static.a in the created toolchain, so we have to copy it by hand.
