### PR TITLE
Fix issue 4

### DIFF
--- a/scripts/build_target.sh
+++ b/scripts/build_target.sh
@@ -4,8 +4,10 @@ ROOTDIR=$(cd $(dirname $(dirname $0)); pwd)
 
 if [ $# -ne 2 ]; then
     echo "Usage: $0 ARCH API" 1>&2
-    echo "  ARCH: arm-linux-androideabi mipsel-linux-android x86" 1>&2
+    echo "  ARCH: aarch64-linux-android arm-linux-androideabi mipsel-linux-android x86" 1>&2
     echo "  API: 1 ... 21" 1>&2
+    echo "Example usage (on MacOS using brew):" 1>&2
+    echo " $0 aarch64-linux-android 21" 1>&2
     exit 1
 fi
 

--- a/scripts/build_target.sh
+++ b/scripts/build_target.sh
@@ -4,7 +4,7 @@ ROOTDIR=$(cd $(dirname $(dirname $0)); pwd)
 
 if [ $# -ne 2 ]; then
     echo "Usage: $0 ARCH API" 1>&2
-    echo "  ARCH: aarch64-linux-android arm-linux-androideabi mipsel-linux-android x86 x86_64" 1>&2
+    echo "  ARCH: aarch64-linux-android arm-linux-androideabi mipsel-linux-android mips64el-linux-android x86 x86_64" 1>&2
     echo "  API: 1 ... 21" 1>&2
     echo "Example usage (on MacOS using brew):" 1>&2
     echo " $0 aarch64-linux-android 21" 1>&2

--- a/scripts/build_target.sh
+++ b/scripts/build_target.sh
@@ -24,6 +24,9 @@ if [ $ARCH = x86 ]; then
 elif [ $ARCH = x86_64 ]; then
     export TOOL_PATH=${ANDROID_TOOLCHAIN}/bin/x86_64-linux-android
     LIB_SUFFIX=64
+elif [ $ARCH = "mips64el-linux-android" ]; then
+    export TOOL_PATH=${ANDROID_TOOLCHAIN}/bin/${ARCH}
+    LIB_SUFFIX=64
 else
     export TOOL_PATH=${ANDROID_TOOLCHAIN}/bin/${ARCH}
 fi

--- a/scripts/build_target.sh
+++ b/scripts/build_target.sh
@@ -4,7 +4,7 @@ ROOTDIR=$(cd $(dirname $(dirname $0)); pwd)
 
 if [ $# -ne 2 ]; then
     echo "Usage: $0 ARCH API" 1>&2
-    echo "  ARCH: aarch64-linux-android arm-linux-androideabi mipsel-linux-android x86" 1>&2
+    echo "  ARCH: aarch64-linux-android arm-linux-androideabi mipsel-linux-android x86 x86_64" 1>&2
     echo "  API: 1 ... 21" 1>&2
     echo "Example usage (on MacOS using brew):" 1>&2
     echo " $0 aarch64-linux-android 21" 1>&2
@@ -21,6 +21,9 @@ export SYSROOT=${ANDROID_TOOLCHAIN}/sysroot
 # that shall be passed to `make-standalone-toolchain.sh` (x86).
 if [ $ARCH = x86 ]; then
     export TOOL_PATH=${ANDROID_TOOLCHAIN}/bin/i686-linux-android
+elif [ $ARCH = x86_64 ]; then
+    export TOOL_PATH=${ANDROID_TOOLCHAIN}/bin/x86_64-linux-android
+    LIB_SUFFIX=64
 else
     export TOOL_PATH=${ANDROID_TOOLCHAIN}/bin/${ARCH}
 fi
@@ -36,7 +39,7 @@ export RANLIB=${TOOL_PATH}-ranlib
 export STRIP=${TOOL_PATH}-strip
 
 export CPPFLAGS="${CPPFLAGS} --sysroot=${SYSROOT} -I${SYSROOT}/usr/include -I${ANDROID_TOOLCHAIN}/include"
-export LDFLAGS="${LDFLAGS} -L${SYSROOT}/usr/lib -L${ANDROID_TOOLCHAIN}/lib -lc++_static -latomic -lm"
+export LDFLAGS="${LDFLAGS} -L${SYSROOT}/usr/lib${LIB_SUFFIX} -L${ANDROID_TOOLCHAIN}/lib -lc++_static -latomic -lm"
 
 (
     cd $ROOTDIR

--- a/scripts/make_toolchain.sh
+++ b/scripts/make_toolchain.sh
@@ -39,6 +39,8 @@ elif [ $ARCH = arm-linux-androideabi ]; then
     cp $NDK_DIR/sources/cxx-stl/llvm-libc++/libs/armeabi/libc++_static.a $INSTALL_DIR/sysroot/usr/lib/
 elif [ $ARCH = mipsel-linux-android ]; then
     cp $NDK_DIR/sources/cxx-stl/llvm-libc++/libs/mips/libc++_static.a $INSTALL_DIR/sysroot/usr/lib/
+elif [ $ARCH = mips64el-linux-android ]; then
+    cp $NDK_DIR/sources/cxx-stl/llvm-libc++/libs/mips64/libc++_static.a $INSTALL_DIR/sysroot/usr/lib/
 else
     echo "FATAL: unknown architecture: $ARCH" 1>&2
     exit 1

--- a/scripts/make_toolchain.sh
+++ b/scripts/make_toolchain.sh
@@ -35,4 +35,7 @@ elif [ $ARCH = arm-linux-androideabi ]; then
     cp $NDK_DIR/sources/cxx-stl/llvm-libc++/libs/armeabi/libc++_static.a $INSTALL_DIR/sysroot/usr/lib/
 elif [ $ARCH = mipsel-linux-android ]; then
     cp $NDK_DIR/sources/cxx-stl/llvm-libc++/libs/mips/libc++_static.a $INSTALL_DIR/sysroot/usr/lib/
+else
+    echo "FATAL: unknown architecture: $ARCH" 1>&2
+    exit 1
 fi

--- a/scripts/make_toolchain.sh
+++ b/scripts/make_toolchain.sh
@@ -3,10 +3,10 @@
 if [ $# -ne 3 ]; then
     echo "Usage: $0 NDK_DIR ARCH API" 1>&2
     echo "  NDK_DIR: path where NDK is installed" 1>&2
-    echo "  ARCH: arm-linux-androideabi mipsel-linux-android x86" 1>&2
+    echo "  ARCH: aarch64-linux-android arm-linux-androideabi mipsel-linux-android x86" 1>&2
     echo "  API: 1 ... 21" 1>&2
     echo "Example usage (on MacOS using brew):" 1>&2
-    echo "  $0 /usr/local/Cellar/android-ndk/r10e" 1>&2
+    echo "  $0 /usr/local/Cellar/android-ndk/r10e aarch64-linux-android 21" 1>&2
     exit 1
 fi
 
@@ -31,6 +31,8 @@ bash $MAKE_TOOLCHAIN \
 
 if [ $ARCH = x86 ]; then
     cp $NDK_DIR/sources/cxx-stl/llvm-libc++/libs/x86/libc++_static.a $INSTALL_DIR/sysroot/usr/lib/
+elif [ $ARCH = aarch64-linux-android ]; then
+    cp $NDK_DIR/sources/cxx-stl/llvm-libc++/libs/arm64-v8a/libc++_static.a $INSTALL_DIR/sysroot/usr/lib/
 elif [ $ARCH = arm-linux-androideabi ]; then
     cp $NDK_DIR/sources/cxx-stl/llvm-libc++/libs/armeabi/libc++_static.a $INSTALL_DIR/sysroot/usr/lib/
 elif [ $ARCH = mipsel-linux-android ]; then

--- a/scripts/make_toolchain.sh
+++ b/scripts/make_toolchain.sh
@@ -3,7 +3,7 @@
 if [ $# -ne 3 ]; then
     echo "Usage: $0 NDK_DIR ARCH API" 1>&2
     echo "  NDK_DIR: path where NDK is installed" 1>&2
-    echo "  ARCH: aarch64-linux-android arm-linux-androideabi mipsel-linux-android x86" 1>&2
+    echo "  ARCH: aarch64-linux-android arm-linux-androideabi mipsel-linux-android x86 x86_64" 1>&2
     echo "  API: 1 ... 21" 1>&2
     echo "Example usage (on MacOS using brew):" 1>&2
     echo "  $0 /usr/local/Cellar/android-ndk/r10e aarch64-linux-android 21" 1>&2
@@ -31,6 +31,8 @@ bash $MAKE_TOOLCHAIN \
 
 if [ $ARCH = x86 ]; then
     cp $NDK_DIR/sources/cxx-stl/llvm-libc++/libs/x86/libc++_static.a $INSTALL_DIR/sysroot/usr/lib/
+elif [ $ARCH = x86_64 ]; then
+    cp $NDK_DIR/sources/cxx-stl/llvm-libc++/libs/x86_64/libc++_static.a $INSTALL_DIR/sysroot/usr/lib/
 elif [ $ARCH = aarch64-linux-android ]; then
     cp $NDK_DIR/sources/cxx-stl/llvm-libc++/libs/arm64-v8a/libc++_static.a $INSTALL_DIR/sysroot/usr/lib/
 elif [ $ARCH = arm-linux-androideabi ]; then

--- a/scripts/make_toolchain.sh
+++ b/scripts/make_toolchain.sh
@@ -3,7 +3,7 @@
 if [ $# -ne 3 ]; then
     echo "Usage: $0 NDK_DIR ARCH API" 1>&2
     echo "  NDK_DIR: path where NDK is installed" 1>&2
-    echo "  ARCH: aarch64-linux-android arm-linux-androideabi mipsel-linux-android x86 x86_64" 1>&2
+    echo "  ARCH: aarch64-linux-android arm-linux-androideabi mipsel-linux-android mips64el-linux-android x86 x86_64" 1>&2
     echo "  API: 1 ... 21" 1>&2
     echo "Example usage (on MacOS using brew):" 1>&2
     echo "  $0 /usr/local/Cellar/android-ndk/r10e aarch64-linux-android 21" 1>&2

--- a/scripts/make_toolchain.sh
+++ b/scripts/make_toolchain.sh
@@ -25,7 +25,7 @@ bash $MAKE_TOOLCHAIN \
   --platform=android-${API} \
   --toolchain=${ARCH}-4.9 \
   --install-dir=${INSTALL_DIR} \
-  --llvm-version=3.5 \
+  --llvm-version=3.6 \
   --stl=libc++ \
   --system=$(uname | tr -s 'A-Z' 'a-z')-x86_64
 


### PR DESCRIPTION
This pull request fixes issue #4. With this pull request merged and measurement-kit/measurement-kit#189 applied, I am able to compile for: mips64el, x86-64, and aarch64-linux-android.

Still no idea how to compile for armeabi-v7a, but this is only a more optimized mode to do Android apps, while armeabi is the basic mode, hence we'll ignore armeabi-v7a for now.

Closes issue #4.
